### PR TITLE
[Mozilla Branding Removal] 2 references to Mozilla

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # hubs-rock-kit
 
-This repository contains some organic rock assets for building scenes in in [Spoke](https://hubs.mozilla.com/spoke). In this repo, you will find the Blender files, as well as textures and the deployment script that is used to publish to Spoke. 
+This repository contains some organic rock assets for building scenes in in [Spoke]. In this repo, you will find the Blender files, as well as textures and the deployment script that is used to publish to Spoke. 
 
-![A set of 3d rock models on a grid background](https://github.com/MozillaReality/hubs-rock-kit/blob/master/assets/RocksInBlender.PNG)
+![A set of 3d rock models on a grid background](https://github.com/hubs-foundation/hubs-rock-kit/blob/master/assets/RocksInBlender.PNG)
 
 The Hubs Rock Kit is one example of configurable pieces that can be used to create new meshes in Spoke. In the future, we plan to make it easy for 3D artists to create their own kits and publish them to Spoke using a similar format as this kit.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hubs-rock-kit
 
-This repository contains some organic rock assets for building scenes in in [Spoke]. In this repo, you will find the Blender files, as well as textures and the deployment script that is used to publish to Spoke. 
+This repository contains some organic rock assets for building scenes in in [Spoke](https://github.com/Hubs-Foundation/Spoke). In this repo, you will find the Blender files, as well as textures and the deployment script that is used to publish to Spoke. 
 
 ![A set of 3d rock models on a grid background](https://github.com/hubs-foundation/hubs-rock-kit/blob/master/assets/RocksInBlender.PNG)
 


### PR DESCRIPTION
Deleted website link to Mozilla Hubs Spoke.
Changed github link from MozillaReality to Hubs-Foundation